### PR TITLE
feat: Dimmer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@
 
 The `MIDI-DMX Bridge` is an Arduino-based hardware and software solution that converts MIDI Continuous Controller signals to DMX commands. The project consists of a hardware schematic and PCB designed using KiCad, an Arduino sketch, and an Arduino library. It can be used to control DMX fixtures such as lights, fog machines, and more.
 
+## Lightning Fixture Compatibility
+
+The `MIDI-DMX Bridge` Arduino project is designed to seamlessly integrate with the lighting fixtures *Stairville CLB4 RGB Compact LED Bar 4* and two *Stairville LED Flood Panel 150*. Here's how the bridge supports these fixtures:
+
+1. **Stairville CLB4 RGB Compact LED Bar 4**:
+    - This LED bar operates in the 14-channel DMX mode, the start address 1.
+    - Each of its four individual LED spots can be controlled independently using the MIDI-DMX Bridge.
+    - Adjust colors, intensity, and effects with precision.
+    - Perfect for creating dynamic lighting displays in various settings.
+
+2. **Stairville LED Flood Panel 150**:
+    - The LED Flood Panel operates in the 4-channel DMX mode, the start addresses are 15 and 19.
+    - Use the MIDI-DMX Bridge to orchestrate its 150 LEDs for wide-area illumination.
+    - Whether it’s stage lighting, architectural displays, or events, this panel delivers impressive results.
+
+
+Remember to consult the user manuals for both fixtures to configure the MIDI-DMX Bridge effectively. Enjoy your creative lighting setups! 🌟
+
 ## Hardware Schematic
 
 The hardware schematic for this project was designed using KiCad. The schematic includes the following components:

--- a/src/arduino-MidiDmxBridge/arduino-MidiDmxBridge.ino
+++ b/src/arduino-MidiDmxBridge/arduino-MidiDmxBridge.ino
@@ -70,9 +70,10 @@ void setup() {
   pinMode(kButtonPin, INPUT);
   pinMode(LED_BUILTIN, OUTPUT);
 
-  uint8_t r[5] = {1, 4, 7, 10, 15};  // DMX channels of red LEDs
-  uint8_t g[5] = {2, 5, 8, 11, 16};  // DMX channels of green LEDs
-  uint8_t b[5] = {3, 6, 9, 12, 17};  // DMX channels of blue LEDs
+  uint8_t r[6] = {1, 4, 7, 10, 16, 20};  // DMX channels of the red LEDs
+  uint8_t g[6] = {2, 5, 8, 11, 17, 21};  // DMX channels of the green LEDs
+  uint8_t b[6] = {3, 6, 9, 12, 18, 22};  // DMX channels of the blue LEDs
+  uint8_t d[3] = {14, 15, 19};           // DMX channels of the dimmers
 
 #ifdef USBSerial
   Serial.begin(9600);  // print info on the serial monitor, USB only
@@ -80,7 +81,8 @@ void setup() {
   DMXSerial.init(DMXController);
   DMXSerial.maxChannel(128);
   MDXBridge.begin();
-  MDXBridge.setStaticScene({{5, r}, {5, g}, {5, b}}, {0xff, 0xf8, 0xa7});
+  MDXBridge.setStaticScene({{6, r}, {6, g}, {6, b}}, {0xff, 0xf8, 0xa7});
+  MDXBridge.setStaticScene({{3, d}, {}, {}}, {0xff, 0x00, 0x00});
 }
 
 /**


### PR DESCRIPTION
In addition to the RGB channels, this feature also takes into account the dimmers of the lighting fixtures. Full support of Stairville CLB4 RGB Compact LED Bar 4 and Stairville LED Flood Panel 150.